### PR TITLE
Bump iOS SDK to version 0.1.76

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,21 @@
+import PackageDescription
+
+let package = Package(
+    name: "Utiq",
+    platforms: [
+        .iOS(.v12)
+    ],
+    products: [
+        .library(
+            name: "Utiq",
+            targets: ["Utiq"]
+        ),
+    ],
+    targets: [
+        .binaryTarget(
+            name: "Utiq",
+            url: "https://github.com/UtiqTech/ios-mobile-sdk/releases/download/0.1.76/Utiq-0.1.76.zip",
+            checksum: "019685ffb68def4bfebe5f89deb0f0a1fdb823fc3156eb4fed1337c639f02cbe"
+        )
+    ] 
+)

--- a/Utiq.podspec
+++ b/Utiq.podspec
@@ -1,0 +1,15 @@
+Pod::Spec.new do |spec|
+  spec.name                     = 'Utiq'
+  spec.version                  = '0.1.76'
+  spec.summary                  = 'Utiq iOS SDK'
+  spec.homepage                 = 'https://github.com/UtiqTech/ios-mobile-sdk'
+  spec.license                  = 'Commercial'
+  spec.author                   = { 'Utiq' => 'support@utiq.com' }
+  spec.platform                 = :ios, '12'
+  spec.source                   = { :http => 'https://github.com/UtiqTech/ios-mobile-sdk/releases/download/0.1.76/Utiq-0.1.76.zip' }
+  spec.ios.deployment_target    = '12'
+  spec.pod_target_xcconfig      = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
+  spec.user_target_xcconfig     = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
+  spec.libraries                = 'c++'
+  spec.vendored_frameworks      = 'Utiq.xcframework'
+end


### PR DESCRIPTION
Automated update for:
- `Utiq.podspec`
- `Package.swift`

This PR bumps the iOS SDK to version `0.1.76`.