### PR TITLE
Bump iOS SDK to version 0.1.76

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version:6.2
+import PackageDescription
+
+let package = Package(
+    name: "Utiq",
+    platforms: [
+        .iOS(.v12)
+    ],
+    products: [
+        .library(
+            name: "Utiq",
+            targets: ["Utiq"]
+        ),
+    ],
+    targets: [
+        .binaryTarget(
+            name: "Utiq",
+            url: "https://github.com/UtiqTech/ios-mobile-sdk/releases/download/0.1.76/Utiq-0.1.76.zip",
+            checksum: "4a435ad290b2c0c0a92a2a95705670082d17ee203568b15f37df0e56d7b75b38"
+        )
+    ] 
+)

--- a/UTIQ.podspec
+++ b/UTIQ.podspec
@@ -1,0 +1,15 @@
+Pod::Spec.new do |spec|
+  spec.name                     = 'UTIQ'
+  spec.version                  = '0.1.76'
+  spec.summary                  = 'Utiq iOS SDK'
+  spec.homepage                 = 'https://github.com/UtiqTech/ios-mobile-sdk'
+  spec.license                  = 'Commercial'
+  spec.author                   = { 'Utiq' => 'support@utiq.com' }
+  spec.platform                 = :ios, '12'
+  spec.source                   = { :http => 'https://github.com/UtiqTech/ios-mobile-sdk/releases/download/0.1.76/Utiq-0.1.76.zip' }
+  spec.ios.deployment_target    = '12'
+  spec.pod_target_xcconfig      = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
+  spec.user_target_xcconfig     = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
+  spec.libraries                = 'c++'
+  spec.vendored_frameworks      = 'Utiq.xcframework'
+end


### PR DESCRIPTION
Automated update for:
- `UTIQ.podspec`
- `Package.swift`

This PR bumps the iOS SDK to version `0.1.76`.