### PR TITLE
Bump iOS SDK to version 0.1.77

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,8 +15,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "Utiq",
-            url: "https://github.com/UtiqTech/ios-mobile-sdk/releases/download/0.1.76/Utiq-0.1.76.zip",
-            checksum: "fecd83a576328308c32643a5294b270219fd567249c3fdea3c2c1de30ebfcaf9"
+            url: "https://github.com/UtiqTech/ios-mobile-sdk/releases/download/0.1.77/Utiq-0.1.77.zip",
+            checksum: "fb99803b72a6c76fff9e424830c172cc0befe8dd7756d443e1d172d36fc94d0e"
         )
     ] 
 )

--- a/UTIQ.podspec
+++ b/UTIQ.podspec
@@ -1,12 +1,12 @@
 Pod::Spec.new do |spec|
   spec.name                     = 'UTIQ'
-  spec.version                  = '0.1.76'
+  spec.version                  = '0.1.77'
   spec.summary                  = 'Utiq iOS SDK'
   spec.homepage                 = 'https://github.com/UtiqTech/ios-mobile-sdk'
   spec.license                  = 'Commercial'
   spec.author                   = { 'Utiq' => 'support@utiq.com' }
   spec.platform                 = :ios, '12'
-  spec.source                   = { :http => 'https://github.com/UtiqTech/ios-mobile-sdk/releases/download/0.1.76/Utiq-0.1.76.zip' }
+  spec.source                   = { :http => 'https://github.com/UtiqTech/ios-mobile-sdk/releases/download/0.1.77/Utiq-0.1.77.zip' }
   spec.ios.deployment_target    = '12'
   spec.pod_target_xcconfig      = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
   spec.user_target_xcconfig     = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }


### PR DESCRIPTION
Automated update for:
- `UTIQ.podspec`
- `Package.swift`

This PR bumps the iOS SDK to version `0.1.77`.