### PR TITLE
Bump iOS SDK to version 0.2.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,8 +15,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "Utiq",
-            url: "https://github.com/UtiqTech/ios-sdk/releases/download/0.1.76/Utiq-0.1.76.zip",
-            checksum: "7a8a817777a11b72c2f606def17946180820fab918fb492145a4cd55c5989ccb"
+            url: "https://github.com/UtiqTech/ios-sdk/releases/download/0.2.0/Utiq-0.2.0.zip",
+            checksum: "da00f189ca334eb0c4bd54a820a69ac41088841b2a0955fe0899aa474461b78f"
         )
     ] 
 )

--- a/UTIQ.podspec
+++ b/UTIQ.podspec
@@ -1,12 +1,12 @@
 Pod::Spec.new do |spec|
   spec.name                     = 'UTIQ'
-  spec.version                  = '0.1.76'
+  spec.version                  = '0.2.0'
   spec.summary                  = 'Utiq iOS SDK'
   spec.homepage                 = 'https://github.com/UtiqTech/ios-sdk'
   spec.license                  = 'Commercial'
   spec.author                   = { 'Utiq' => 'support@utiq.com' }
   spec.platform                 = :ios, '12'
-  spec.source                   = { :http => 'https://github.com/UtiqTech/ios-sdk/releases/download/0.1.76/Utiq-0.1.76.zip' }
+  spec.source                   = { :http => 'https://github.com/UtiqTech/ios-sdk/releases/download/0.2.0/Utiq-0.2.0.zip' }
   spec.ios.deployment_target    = '12'
   spec.pod_target_xcconfig      = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
   spec.user_target_xcconfig     = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }


### PR DESCRIPTION
Automated update for:
- `UTIQ.podspec`
- `Package.swift`

This PR bumps the iOS SDK to version `0.2.0`.