### PR TITLE
Bump iOS SDK to version 1.0.2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,8 +15,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "Utiq",
-            url: "https://github.com/UtiqTech/ios-sdk/releases/download/0.2.4/Utiq-0.2.4.zip",
-            checksum: "b5d431169f2f290be04085359605232a63cde668914c92ef6976585cbff21803"
+            url: "https://github.com/UtiqTech/ios-sdk/releases/download/1.0.2/Utiq-1.0.2.zip",
+            checksum: "c4270fb5d4f5451dca9f9ff779a298af261ba5d704bdf9d40343dbeb004f6f57"
         )
     ] 
 )

--- a/UTIQ.podspec
+++ b/UTIQ.podspec
@@ -1,12 +1,12 @@
 Pod::Spec.new do |spec|
   spec.name                     = 'UTIQ'
-  spec.version                  = '0.2.4'
+  spec.version                  = '1.0.2'
   spec.summary                  = 'Utiq iOS SDK'
   spec.homepage                 = 'https://github.com/UtiqTech/ios-sdk'
   spec.license                  = 'Commercial'
   spec.author                   = { 'Utiq' => 'support@utiq.com' }
   spec.platform                 = :ios, '12'
-  spec.source                   = { :http => 'https://github.com/UtiqTech/ios-sdk/releases/download/0.2.4/Utiq-0.2.4.zip' }
+  spec.source                   = { :http => 'https://github.com/UtiqTech/ios-sdk/releases/download/1.0.2/Utiq-1.0.2.zip' }
   spec.ios.deployment_target    = '12'
   spec.pod_target_xcconfig      = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
   spec.user_target_xcconfig     = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }


### PR DESCRIPTION
Automated update for:
- `UTIQ.podspec`
- `Package.swift`

This PR bumps the iOS SDK to version `1.0.2`.