### PR TITLE
Bump iOS SDK to version 1.0.8

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,8 +15,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "Utiq",
-            url: "https://github.com/UtiqTech/ios-sdk/releases/download/1.0.7/Utiq-1.0.7.zip",
-            checksum: "654ad632bd13690a648fb93a7572ad06e66b891983bf52bc19a70b01a2b0f6fc"
+            url: "https://github.com/UtiqTech/ios-sdk/releases/download/1.0.8/Utiq-1.0.8.zip",
+            checksum: "c093f4afe07447dc88af0d4e20b789573e32d2dd1e054ce49ebf5d1ef1f0fe76"
         )
     ] 
 )

--- a/UTIQ.podspec
+++ b/UTIQ.podspec
@@ -1,12 +1,12 @@
 Pod::Spec.new do |spec|
   spec.name                     = 'UTIQ'
-  spec.version                  = '1.0.7'
+  spec.version                  = '1.0.8'
   spec.summary                  = 'Utiq iOS SDK'
   spec.homepage                 = 'https://github.com/UtiqTech/ios-sdk'
   spec.license                  = 'Commercial'
   spec.author                   = { 'Utiq' => 'support@utiq.com' }
   spec.platform                 = :ios, '12'
-  spec.source                   = { :http => 'https://github.com/UtiqTech/ios-sdk/releases/download/1.0.7/Utiq-1.0.7.zip' }
+  spec.source                   = { :http => 'https://github.com/UtiqTech/ios-sdk/releases/download/1.0.8/Utiq-1.0.8.zip' }
   spec.ios.deployment_target    = '12'
   spec.pod_target_xcconfig      = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
   spec.user_target_xcconfig     = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }


### PR DESCRIPTION
Automated update for:
- `UTIQ.podspec`
- `Package.swift`

This PR bumps the iOS SDK to version `1.0.8`.