### PR TITLE
Bump iOS SDK to version 2.0.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,8 +15,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "Utiq",
-            url: "https://github.com/UtiqTech/ios-sdk/releases/download/1.0.10/Utiq-1.0.10.zip",
-            checksum: "ab3628c758fb5c246b7e9a8bf183a0a5bdf0866dd8b3456498e0a2fef607defd"
+            url: "https://github.com/UtiqTech/ios-sdk/releases/download/v2.0.0/Utiq-2.0.0.zip",
+            checksum: "9feb06f523c0bbaf9d75faa7eae84a69ad402a322d3c31ee97d3a589a7702fdf"
         )
     ] 
 )


### PR DESCRIPTION
Automated update for `Package.swift`.

This PR bumps the iOS SDK to version `2.0.0`.